### PR TITLE
Fix-queue-overflow

### DIFF
--- a/app/styles/config/_layouts.scss
+++ b/app/styles/config/_layouts.scss
@@ -1,11 +1,11 @@
 // Grids
 @mixin grid-cols($nof_cols) {
   display: grid;
-  grid-template-columns: repeat($nof_cols, 1fr);
+  grid-template-columns: repeat($nof_cols, minmax(0, 1fr));
 }
 @mixin grid-rows($nof_rows) {
   display: grid;
-  grid-template-rows: repeat($nof_rows, 1fr);
+  grid-template-rows: repeat($nof_rows, minmax(0, 1fr));
 }
 
 // Flexbox


### PR DESCRIPTION
Ison debuggauksen tuloksena ongelma olikin paljon korkeemmalla html-puussa kun luulin. Me ei oltu limitoitu etusivun perus grid-layoutin minimi- ja maksimikokoa, joihin käytettiin noita grid-cols ja grid-rows mixineitä. Nyt pitäs toimia etusivulla myös queue-cardin scrollaus eikä toi mielestäni riko mitään muitakaan tyylejä